### PR TITLE
Added default <meta> description for tags

### DIFF
--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -84,6 +84,10 @@ flarum-tags:
       removed_tags_text: "{username} removed the {tagsRemoved}."
       tags_text: "{tags} tag|{tags} tags"
 
+    # These translations are displayed on the <meta>
+    meta_description:
+      discussions_tagged_text: "Discussions with the '{tag}' tag"
+
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
 


### PR DESCRIPTION
Continuing the work on flarum/flarum-ext-tags#48, this is adding a translatable string for a default description for tags without an user inputed one.