### PR TITLE
Fix translation sorting

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -94,11 +94,10 @@ core:
       driver_label: Driver
       from_label: Sender
       heading: => core.ref.email
-      mailgun_heading: Mailgun Settings
       mail_encryption_label: Encryption
       mail_host_label: Host
-      mail_mailgun_secret_label: Secret key
       mail_mailgun_domain_label: Domain
+      mail_mailgun_secret_label: Secret key
       mail_mandrill_secret_label: Secret key
       mail_password_label: => core.ref.password
       mail_port_label: Port
@@ -106,6 +105,7 @@ core:
       mail_ses_region_label: Region
       mail_ses_secret_label: Secret
       mail_username_label: => core.ref.username
+      mailgun_heading: Mailgun Settings
       mandrill_heading: Mandrill Settings
       ses_heading: SES Settings
       smtp_heading: SMTP Settings


### PR DESCRIPTION
As reported by @Hiobi on the French language pack ([see commit](https://github.com/milescellar/lang-french/commit/416cbd9da9e0ed1beda69a5cdd1f8b1702c9b60b)).