### PR TITLE
Improve the "last seen time" permission text

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -162,7 +162,7 @@ core:
       sign_up_label: Sign up
       start_discussions_label: Start discussions
       view_discussions_label: View discussions
-      view_last_seen_at_label: View user last seen time
+      view_last_seen_at_label: Always view user last seen time
       view_post_ips_label: View post IP addresses
       view_user_list_label: View user list
 


### PR DESCRIPTION
This commit makes a bit clearer the fact that the permission serves to override the privacy settings of users. Without the "Always" word, one might think that the permission is required for users to see each other's last seen time in general, which is not true.