### PR TITLE
Fix `date_format` message in validation.yml

### DIFF
--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -18,7 +18,7 @@ validation:
   confirmed: "The :attribute confirmation does not match."
   date: "The :attribute is not a valid date."
   date_equals: "The :attribute must be a date equal to :date."
-  date_format: "The :attribute does not match the format :other."
+  date_format: "The :attribute does not match the format :format."
   different: "The :attribute and :other must be different."
   digits: "The :attribute must be :digits digits."
   digits_between: "The :attribute must be between :min and :max digits."


### PR DESCRIPTION
Source: https://github.com/laravel/laravel/blob/b46c16b4246c7dc648158221c49f5b2e785e7c30/resources/lang/en/validation.php#L36

I'm not sure where did `:other`  come from.