### PR TITLE
Changed display names of primary and secondary tags to categories and tags

### DIFF
--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -4,6 +4,9 @@ flarum-tags:
   # UNIQUE KEYS - The following keys are used in only one location each.
   ##
 
+  # Please note that the display names of primary tags and secondary tags have been changed to
+  # categories and tags respectively to improve ease of use. The internal logic has not been changed.
+
   # Translations in this namespace are used by the admin interface.
   admin:
 
@@ -40,18 +43,18 @@ flarum-tags:
     # These translations are used in the Tag Settings modal dialog.
     tag_settings:
       range_separator_text: " to "
-      required_primary_heading: Required Number of Primary Tags
-      required_primary_text: Enter the minimum and maximum number of primary tags that may be applied to a discussion.
-      required_secondary_heading: Required Number of Secondary Tags
-      required_secondary_text: Enter the minimum and maximum number of secondary tags that may be applied to a discussion.
+      required_primary_heading: Required Number of Categories
+      required_primary_text: Enter the minimum and maximum number of categories that may be applied to a discussion.
+      required_secondary_heading: Required Number of Tags
+      required_secondary_text: Enter the minimum and maximum number of tags that may be applied to a discussion.
       title: Tag Settings
 
     # These translations are used in the Tags page.
     tags:
-      about_tags_text: "Tags are used to categorize discussions. Primary tags are like traditional forum categories: they can be arranged in a two-level hierarchy. Secondary tags do not have hierarchy or order, and are useful for micro-categorization."
+      about_tags_text: "Tags are used to categorize discussions. Categories can be arranged in a two-level hierarchy to organize your forum. Tags do not have hierarchy or order, and are useful for micro-categorization."
       create_tag_button: => flarum-tags.ref.create_tag
-      primary_heading: Primary Tags
-      secondary_heading: Secondary Tags
+      primary_heading: Categories
+      secondary_heading: Tags
       settings_button: Settings
 
   # Translations in this namespace are used by the forum user interface.
@@ -59,7 +62,7 @@ flarum-tags:
 
     # These translations are used by the Choose Tags modal dialog.
     choose_tags:
-      choose_primary_placeholder: "Choose a primary tag|Choose {count} primary tags"
+      choose_primary_placeholder: "Choose a category|Choose {count} category"
       choose_secondary_placeholder: "Choose 1 more tag|Choose {count} more tags"
       edit_title: "Edit Tags for {title}"
       submit_button: => core.ref.okay


### PR DESCRIPTION
The naming of tags as "primary" and "secondary" has long been confusing to new users, especially considering that subtags also exist. It has been proposed several times to change the naming, but discussions about the matter devolved into a discussion of totally revamping the tags extension (https://github.com/flarum/core/issues/395). The discussion has long gone stale, and there is no WIP (or even a consensus) on the discussed changes. This PR aims to provide, possibly temporarily, a clearer interface for new forum admins, while not touching the backend/logic so that discussion on possible revamps can eventually continue. 