### PR TITLE
Posts are no longer deleted when users are deleted, so the error mess…

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -410,7 +410,7 @@ core:
     user_controls:
       button: Controls
       delete_button: => core.ref.delete
-      delete_confirmation: "Are you sure you want to delete this user? All of the user's posts will be deleted."
+      delete_confirmation: "Are you sure you want to delete this user? The user's posts will NOT be deleted."
       delete_error_message: "Deletion of user <i>{username} ({email})</i> failed"
       delete_success_message: "User <i>{username} ({email})</i> was deleted"
       edit_button: => core.ref.edit


### PR DESCRIPTION
…age should reflect that.

Fixes https://github.com/flarum/core/issues/1928 by updating the warning message when deleting a user.