### PR TITLE
Strings containing specific characters must be quoted

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -109,8 +109,8 @@ core:
       not_sending_message: Flarum currently does not send emails. This can be due to the selected driver, or errors in its configuration.
       send_test_mail_button: Send
       send_test_mail_heading: Send Test Mail
-      send_test_mail_success: Test mail sent successfully!
-      send_test_mail_text: This will send an email using the above configuration to your email, {email}.
+      send_test_mail_success: "Test mail sent successfully!"
+      send_test_mail_text: "This will send an email using the above configuration to your email, {email}."
       smtp_heading: SMTP Settings
       submit_button: => core.ref.save_changes
       text: Configure the driver, settings and addresses your forum will use to send email.


### PR DESCRIPTION
Please see: https://symfony.com/doc/current/components/yaml/yaml_format.html#strings